### PR TITLE
feature(PT-5101): Ethereum poller always publishes latest block

### DIFF
--- a/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumClient.kt
+++ b/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumClient.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirst
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -34,7 +33,6 @@ import scalether.domain.response.Log
 import scalether.domain.response.Transaction
 import scalether.util.Hex
 import java.math.BigInteger
-import java.time.Duration
 
 @ExperimentalCoroutinesApi
 @Component
@@ -70,26 +68,16 @@ class EthereumClient(
         }
     }
 
-    override val newBlocks: Flow<EthereumBlockchainBlock> = subscriber.newHeads()
-        .flatMap { block ->
-            logger.info("Detected new block from subscriber: ${block.block.blockNumber}")
-            ethereum
-                .ethGetFullBlockByHash(block.block.hash())
-                .wrapWithRetry("ethGetFullBlockByHash", block.block.hash(), block.block.number())
-                .map { ReceivedBlock(it, block.receivedTime) }
-        }
-        .map { EthereumBlockchainBlock(it) }
-        .timeout(Duration.ofMinutes(5))
-        .doOnCancel {
-            logger.info("Subscription canceled")
-        }
-        .doOnError { e ->
-            logger.warn("Subscription error: ${e.message}", e)
-        }
-        .doOnComplete {
-            logger.info("Subscription completed")
-        }
-        .asFlow()
+    override val newBlocks: Flow<EthereumBlockchainBlock> =
+        subscriber.newHeads()
+            .map { block ->
+                logger.info("Detected new block from subscriber: ${block.block.blockNumber}")
+                ethereum
+                    .ethGetFullBlockByHash(block.block.hash())
+                    .wrapWithRetry("ethGetFullBlockByHash", block.block.hash(), block.block.number())
+                    .map { EthereumBlockchainBlock(ReceivedBlock(it, block.receivedTime)) }
+                    .awaitFirst()
+            }
 
     override suspend fun getBlocks(numbers: List<Long>): List<EthereumBlockchainBlock> =
         coroutineScope { numbers.map { asyncWithTraceId(context = NonCancellable) { getBlock(it) } }.awaitAll() }
@@ -252,7 +240,7 @@ class EthereumClient(
                 val transaction = transactions[ethLog.transactionHash()]
                     ?: throw NonRetryableBlockchainClientException(
                         "Transaction #${ethLog.transactionHash()} is not found in the block $ethFullBlock\n" +
-                            "All transactions: $transactions"
+                                "All transactions: $transactions"
                     )
                 EthereumBlockchainLog(
                     ethLog = ethLog,

--- a/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockPoller.kt
+++ b/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockPoller.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactor.asFlux
 import kotlinx.coroutines.time.delay
 import org.slf4j.LoggerFactory
+import reactor.core.publisher.BufferOverflowStrategy.DROP_OLDEST
 import reactor.core.publisher.Flux
 import scalether.core.MonoEthereum
 import scalether.domain.response.Block
@@ -30,5 +31,5 @@ class EthereumNewBlockPoller(
             if (head != null) send(ReceivedBlock(head))
             delay(pollingDelay)
         }
-    }.asFlux()
+    }.asFlux().onBackpressureBuffer(1, DROP_OLDEST)
 }

--- a/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockPoller.kt
+++ b/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockPoller.kt
@@ -3,16 +3,16 @@ package com.rarible.blockchain.scanner.ethereum.client
 import com.rarible.blockchain.scanner.framework.model.ReceivedBlock
 import io.daonomic.rpc.domain.Word
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.reactive.awaitFirstOrNull
-import kotlinx.coroutines.reactor.asFlux
 import kotlinx.coroutines.time.delay
 import org.slf4j.LoggerFactory
-import reactor.core.publisher.BufferOverflowStrategy.DROP_OLDEST
-import reactor.core.publisher.Flux
 import scalether.core.MonoEthereum
 import scalether.domain.response.Block
+import java.math.BigInteger
 import java.time.Duration
 
 @ExperimentalCoroutinesApi
@@ -23,13 +23,27 @@ class EthereumNewBlockPoller(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    override fun newHeads(): Flux<ReceivedBlock<Block<Word>>> = channelFlow<ReceivedBlock<Block<Word>>> {
+    override fun newHeads(): Flow<ReceivedBlock<Block<Word>>> = channelFlow {
+        var previousHead: BigInteger? = null
+        var previousBlockHash: Word? = null
+        logger.info("starting new block poller ...")
         while (isClosedForSend.not()) {
-            val headBlockNumber = ethereum.ethBlockNumber().awaitFirst()
-            val head = ethereum.ethGetBlockByNumber(headBlockNumber).awaitFirstOrNull()
-            logger.info("Poller get new head block: ${head?.number()}")
-            if (head != null) send(ReceivedBlock(head))
+            try {
+                val latestHead = ethereum.ethBlockNumber().awaitFirstOrNull()
+                if (latestHead != null) {
+                    val latestBlock = ethereum.ethGetBlockByNumber(latestHead).awaitFirstOrNull()
+                    if (latestBlock != null && (latestHead != previousHead || latestBlock.hash() != previousBlockHash)) {
+                        logger.info("got new head=[$latestHead, ${latestBlock.hash()}], previous=[$previousHead, $previousBlockHash]")
+                        send(ReceivedBlock(latestBlock))
+                        previousHead = latestHead
+                        previousBlockHash = latestBlock.hash()
+                    }
+                }
+            } catch (e: Exception) {
+                logger.warn("error fetching block head, previous=$previousHead", e)
+            }
             delay(pollingDelay)
         }
-    }.asFlux().onBackpressureBuffer(1, DROP_OLDEST)
+        logger.info("new block poller closed!")
+    }.buffer(0, onBufferOverflow = DROP_OLDEST)
 }

--- a/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockSubscriber.kt
+++ b/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockSubscriber.kt
@@ -2,9 +2,9 @@ package com.rarible.blockchain.scanner.ethereum.client
 
 import com.rarible.blockchain.scanner.framework.model.ReceivedBlock
 import io.daonomic.rpc.domain.Word
-import reactor.core.publisher.Flux
+import kotlinx.coroutines.flow.Flow
 import scalether.domain.response.Block
 
 interface EthereumNewBlockSubscriber {
-    fun newHeads(): Flux<ReceivedBlock<Block<Word>>>
+    fun newHeads(): Flow<ReceivedBlock<Block<Word>>>
 }

--- a/ethereum/src/test/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockPollerTest.kt
+++ b/ethereum/src/test/kotlin/com/rarible/blockchain/scanner/ethereum/client/EthereumNewBlockPollerTest.kt
@@ -1,11 +1,13 @@
 package com.rarible.blockchain.scanner.ethereum.client
 
+import com.rarible.blockchain.scanner.framework.model.ReceivedBlock
 import io.daonomic.rpc.domain.Word
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
+import org.apache.commons.lang3.RandomUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
@@ -17,10 +19,9 @@ import java.time.Duration
 @Suppress("ReactiveStreamsUnusedPublisher")
 internal class EthereumNewBlockPollerTest {
     private val ethereum = mockk<MonoEthereum>()
-    private val pollingDelay = Duration.ZERO
 
     @ExperimentalCoroutinesApi
-    private val poller = EthereumNewBlockPoller(ethereum, pollingDelay)
+    private val poller = EthereumNewBlockPoller(ethereum, Duration.ofSeconds(2))
 
     @ExperimentalCoroutinesApi
     @Test
@@ -29,18 +30,23 @@ internal class EthereumNewBlockPollerTest {
         val blockNumber2 = BigInteger("2")
         val block1 = mockk<Block<Word>> {
             every { number() } returns BigInteger.ONE
+            every { hash() } returns Word(RandomUtils.nextBytes(32))
         }
         val block2 = mockk<Block<Word>> {
             every { number() } returns BigInteger.TEN
+            every { hash() } returns Word(RandomUtils.nextBytes(32))
         }
         every { ethereum.ethBlockNumber() } returnsMany listOf(
             Mono.just(blockNumber1),
+            Mono.just(blockNumber1),
+            Mono.just(blockNumber2),
             Mono.just(blockNumber2),
         )
         every { ethereum.ethGetBlockByNumber(blockNumber1) } returns Mono.just(block1)
         every { ethereum.ethGetBlockByNumber(blockNumber2) } returns Mono.just(block2)
 
-        val result = poller.newHeads().take(2).collectList().awaitFirst()
+        val result = mutableListOf<ReceivedBlock<Block<Word>>>()
+        poller.newHeads().take(2).collect { receivedBlock -> result.add(receivedBlock) }
         assertThat(result.map { it.block }).containsExactly(block1, block2)
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.8.8</revision>
+        <revision>2.8.9</revision>
 
         <rarible.ethereum.version>1.8.0</rarible.ethereum.version>
         <rarible.core.version>2.7.14</rarible.core.version>


### PR DESCRIPTION
The idea is to discard any intermediate blocks seen by the poller while the block handler is still handling the previous block.

This will allow the block handler to have a wider range of blocks to process.

Note: I am still investigating the stable/unstable logic to see if we could do further optimisations 