### PR TITLE
PT-5929 Fix Spring snafu

### DIFF
--- a/core/src/main/kotlin/com/rarible/blockchain/scanner/configuration/BlockchainScannerConfiguration.kt
+++ b/core/src/main/kotlin/com/rarible/blockchain/scanner/configuration/BlockchainScannerConfiguration.kt
@@ -1,14 +1,26 @@
 package com.rarible.blockchain.scanner.configuration
 
 import com.rarible.blockchain.scanner.BlockchainScanner
+import com.rarible.blockchain.scanner.BlockchainScannerManager
 import com.rarible.blockchain.scanner.block.BlockRepository
+import com.rarible.blockchain.scanner.framework.client.BlockchainBlock
+import com.rarible.blockchain.scanner.framework.client.BlockchainLog
+import com.rarible.blockchain.scanner.framework.model.Descriptor
+import com.rarible.blockchain.scanner.framework.model.LogRecord
+import com.rarible.blockchain.scanner.framework.model.LogStorage
+import com.rarible.blockchain.scanner.framework.model.TransactionRecord
+import com.rarible.blockchain.scanner.framework.subscriber.LogEventSubscriber
 import com.rarible.blockchain.scanner.monitoring.BlockMonitor
 import com.rarible.blockchain.scanner.monitoring.BlockchainMonitor
 import com.rarible.blockchain.scanner.monitoring.LogMonitor
 import com.rarible.blockchain.scanner.monitoring.Monitor
 import com.rarible.blockchain.scanner.monitoring.MonitoringWorker
 import com.rarible.blockchain.scanner.monitoring.ReindexMonitor
+import com.rarible.blockchain.scanner.reconciliation.LogReconciliationMonitor
+import com.rarible.blockchain.scanner.reconciliation.ReconciliationLogHandler
+import com.rarible.blockchain.scanner.reconciliation.ReconciliationLogHandlerImpl
 import com.rarible.blockchain.scanner.reconciliation.ReconciliationLogWorkerHandler
+import com.rarible.blockchain.scanner.reconciliation.ReconciliationStateRepository
 import com.rarible.core.daemon.DaemonWorkerProperties
 import com.rarible.core.daemon.job.JobDaemonWorker
 import com.rarible.core.daemon.sequential.SequentialDaemonWorker
@@ -69,4 +81,48 @@ class BlockchainScannerConfiguration(
             }
         }
     }
+
+    @Bean
+    fun reconciliationLogWorkerHandler(
+        reconciliationLogHandler: ReconciliationLogHandler,
+        stateRepository: ReconciliationStateRepository,
+        blockRepository: BlockRepository,
+        scannerProperties: BlockchainScannerProperties,
+        monitor: LogReconciliationMonitor,
+    ): ReconciliationLogWorkerHandler {
+        return ReconciliationLogWorkerHandler(
+            reconciliationLogHandler,
+            stateRepository,
+            blockRepository,
+            scannerProperties,
+            monitor,
+        )
+    }
+
+    @Bean
+    fun reconciliationMonitor(meterRegistry: MeterRegistry): LogReconciliationMonitor {
+        return LogReconciliationMonitor(properties, meterRegistry)
+    }
+
+    @Bean
+    fun <BB : BlockchainBlock,
+        BL : BlockchainLog,
+        R : LogRecord,
+        TR : TransactionRecord,
+        D : Descriptor<S>,
+        S : LogStorage
+        > reconciliationLogHandler(
+        manager: BlockchainScannerManager<BB, BL, R, TR, D, S>,
+        scannerProperties: BlockchainScannerProperties,
+        monitor: LogReconciliationMonitor,
+        subscribers: List<LogEventSubscriber<BB, BL, R, D, S>>,
+    ): ReconciliationLogHandler = ReconciliationLogHandlerImpl(
+        reconciliationProperties = scannerProperties.reconciliation,
+        blockchainClient = manager.retryableClient,
+        logHandlerFactory = manager.logHandlerFactory,
+        reindexer = manager.blockReindexer,
+        planner = manager.blockScanPlanner,
+        monitor = monitor,
+        subscribers = subscribers,
+    )
 }

--- a/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/LogReconciliationMonitor.kt
+++ b/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/LogReconciliationMonitor.kt
@@ -4,9 +4,7 @@ import com.rarible.blockchain.scanner.configuration.BlockchainScannerProperties
 import com.rarible.blockchain.scanner.monitoring.AbstractMonitor
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
-import org.springframework.stereotype.Component
 
-@Component
 class LogReconciliationMonitor(
     properties: BlockchainScannerProperties,
     meterRegistry: MeterRegistry

--- a/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogHandlerImpl.kt
+++ b/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogHandlerImpl.kt
@@ -1,7 +1,5 @@
 package com.rarible.blockchain.scanner.reconciliation
 
-import com.rarible.blockchain.scanner.BlockchainScannerManager
-import com.rarible.blockchain.scanner.configuration.BlockchainScannerProperties
 import com.rarible.blockchain.scanner.configuration.ReconciliationProperties
 import com.rarible.blockchain.scanner.framework.client.BlockchainBlock
 import com.rarible.blockchain.scanner.framework.client.BlockchainClient
@@ -26,10 +24,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.stereotype.Component
 
-@Component
 class ReconciliationLogHandlerImpl<
     BB : BlockchainBlock,
     BL : BlockchainLog,
@@ -45,22 +40,6 @@ class ReconciliationLogHandlerImpl<
     private val monitor: LogReconciliationMonitor,
     subscribers: List<LogEventSubscriber<BB, BL, R, D, S>>,
 ) : ReconciliationLogHandler {
-
-    @Autowired
-    constructor(
-        manager: BlockchainScannerManager<BB, BL, R, *, D, S>,
-        scannerProperties: BlockchainScannerProperties,
-        monitor: LogReconciliationMonitor,
-        subscribers: List<LogEventSubscriber<BB, BL, R, D, S>>,
-    ) : this(
-        reconciliationProperties = scannerProperties.reconciliation,
-        blockchainClient = manager.retryableClient,
-        logHandlerFactory = manager.logHandlerFactory,
-        reindexer = manager.blockReindexer,
-        planner = manager.blockScanPlanner,
-        monitor = monitor,
-        subscribers = subscribers,
-    )
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 

--- a/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogWorkerHandler.kt
+++ b/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogWorkerHandler.kt
@@ -6,9 +6,7 @@ import com.rarible.blockchain.scanner.handler.TypedBlockRange
 import com.rarible.core.daemon.job.JobHandler
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 
-@Component
 class ReconciliationLogWorkerHandler(
     private val reconciliationLogHandler: ReconciliationLogHandler,
     private val stateRepository: ReconciliationStateRepository,

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>3.0.1</revision>
+        <revision>3.0.2</revision>
 
         <rarible.ethereum.version>1.8.10</rarible.ethereum.version>
         <rarible.core.version>2.7.14</rarible.core.version>


### PR DESCRIPTION
For some reason, when LogReconciliationMonitor is a @Component, it cannot receive BlockchainScannerProperties ("no qualifying bean") when Spring starts up in ethereum-indexer. And when ReconciliationLogHandlerImpl is a @Component, it cannot receive BlockchainScannerManager ("no qualifying bean"). But somehow it works if they are registered through a @Configuration.