### PR TITLE
PT-5930 Rename ReconciliationProperties.autoReindex

### DIFF
--- a/core/src/main/kotlin/com/rarible/blockchain/scanner/configuration/ReconciliationProperties.kt
+++ b/core/src/main/kotlin/com/rarible/blockchain/scanner/configuration/ReconciliationProperties.kt
@@ -5,7 +5,7 @@ import java.time.Duration
 data class ReconciliationProperties(
     val enabled: Boolean = false,
     val blockHandleParallelism: Int = 50,
-    val autoReindex: ReindexMode = ReindexMode.WITH_EVENTS,
+    val autoReindexMode: ReindexMode = ReindexMode.WITH_EVENTS,
     val reindexBatchSize: Int = 50,
     val reindexParallelism: Int = 10,
     val checkPeriod: Duration = Duration.ofMinutes(1),

--- a/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogHandlerImpl.kt
+++ b/core/src/main/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogHandlerImpl.kt
@@ -81,8 +81,8 @@ class ReconciliationLogHandlerImpl<
                 }.filterNotNull()
                 .toRanges()
 
-            if (reconciliationProperties.autoReindex.enabled) {
-                reindex(reconciledBlockRangesFlow, reconciliationProperties.autoReindex.publishEvents)
+            if (reconciliationProperties.autoReindexMode.enabled) {
+                reindex(reconciledBlockRangesFlow, reconciliationProperties.autoReindexMode.publishEvents)
             } else {
                 reconciledBlockRangesFlow.collect()
             }

--- a/core/src/test/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogHandlerImplTest.kt
+++ b/core/src/test/kotlin/com/rarible/blockchain/scanner/reconciliation/ReconciliationLogHandlerImplTest.kt
@@ -222,7 +222,7 @@ internal class ReconciliationLogHandlerImplTest {
         val handler = create(
             listOf(subscriber11a),
             reconciliationProperties = ReconciliationProperties(
-                autoReindex = ReconciliationProperties.ReindexMode.WITHOUT_EVENTS
+                autoReindexMode = ReconciliationProperties.ReindexMode.WITHOUT_EVENTS
             )
         )
 
@@ -235,7 +235,7 @@ internal class ReconciliationLogHandlerImplTest {
     private fun create(
         subscribers: List<TestLogEventSubscriber>,
         reconciliationProperties: ReconciliationProperties = ReconciliationProperties(
-            autoReindex = ReconciliationProperties.ReindexMode.DISABLED
+            autoReindexMode = ReconciliationProperties.ReindexMode.DISABLED
         )
     ): ReconciliationLogHandler {
         return ReconciliationLogHandlerImpl(

--- a/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/configuration/EthereumScannerProperties.kt
+++ b/ethereum/src/main/kotlin/com/rarible/blockchain/scanner/ethereum/configuration/EthereumScannerProperties.kt
@@ -25,7 +25,7 @@ data class EthereumScannerProperties(
     override val task: TaskProperties = TaskProperties(),
     override val reconciliation: ReconciliationProperties = ReconciliationProperties(
         enabled = true,
-        autoReindex = ReconciliationProperties.ReindexMode.WITHOUT_EVENTS,
+        autoReindexMode = ReconciliationProperties.ReindexMode.WITHOUT_EVENTS,
     ),
     val maxPendingLogDuration: Long = Duration.ofHours(2).toMillis(),
     val blockPoller: BlockPollerProperties = BlockPollerProperties(),

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>3.0.6</revision>
+        <revision>3.0.7</revision>
 
         <rarible.ethereum.version>1.8.10</rarible.ethereum.version>
         <rarible.core.version>2.7.26</rarible.core.version>


### PR DESCRIPTION
In order to avoid downtime when releasing flow-indexer with updated blockchain-scanner: we already have autoReindex Boolean config in protocol-config for it